### PR TITLE
add separate method to connect to SQL database post-init

### DIFF
--- a/tests/store/test_store_core.py
+++ b/tests/store/test_store_core.py
@@ -9,3 +9,17 @@ class TestStore(object):
 
   def test_init(self):
     pass
+
+
+def test_lazy_load():
+  """Test connection after post-init."""
+  store = Store()
+
+  # now we shouldn't have access to aliases
+  assert hasattr(store, 'query') == False
+
+  store.connect(':memory:')
+
+  # ... but now we do!
+  assert hasattr(store, 'query')
+  assert store.dialect == 'sqlite'


### PR DESCRIPTION
Adding ability to lazy load the Store class.

``` python
>>> from chanjo import Store
>>> store = Store()
>>> store.connect(':memory:')
```
