### PR TITLE
Transcript schema

### DIFF
--- a/chanjo/cli/calculate.py
+++ b/chanjo/cli/calculate.py
@@ -5,16 +5,22 @@ import click
 
 from chanjo.store import ChanjoAPI
 from chanjo.store.utils import filter_samples
+from chanjo.store.models import BASE
+from chanjo.store.txmodels import BASE as TXBASE
 from .utils import dump_json
 
 logger = logging.getLogger(__name__)
 
 
 @click.group()
+@click.option('-t', '--transcripts', is_flag=True,
+              help='focus only on transcripts on the database level')
 @click.pass_context
-def calculate(context):
+def calculate(context, transcripts):
     """Calculate simple metrics from the database."""
-    context.api = ChanjoAPI(uri=context.obj['database'])
+    only_tx = transcripts or context.obj.get('transcripts') or False
+    base = TXBASE if only_tx else BASE
+    context.api = ChanjoAPI(uri=context.obj['database'], base=base)
 
 
 @calculate.command()

--- a/chanjo/cli/database.py
+++ b/chanjo/cli/database.py
@@ -6,15 +6,21 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from chanjo.store import Store
 from chanjo.store.models import ExonStatistic, Sample
+from chanjo.store.models import BASE
+from chanjo.store.txmodels import BASE as TXBASE
 
 logger = logging.getLogger(__name__)
 
 
 @click.group()
+@click.option('-t', '--transcripts', is_flag=True,
+              help='focus only on transcripts on the database level')
 @click.pass_context
-def db(context):
+def db(context, transcripts):
     """Interact with the database for maintainance tasks."""
-    context.db = Store(uri=context.obj['database'])
+    only_tx = transcripts or context.obj.get('transcripts') or False
+    base = TXBASE if only_tx else BASE
+    context.db = Store(uri=context.obj['database'], base=base)
 
 
 @db.command()

--- a/chanjo/cli/init.py
+++ b/chanjo/cli/init.py
@@ -8,6 +8,8 @@ import chanjo
 from chanjo.compat import iteritems
 from chanjo.config import questionnaire
 from chanjo.store import Store
+from chanjo.store.models import BASE
+from chanjo.store.txmodels import BASE as TXBASE
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +18,10 @@ logger = logging.getLogger(__name__)
 @click.option('-s', '--setup', is_flag=True, help='setup database tables')
 @click.option('-r', '--reset', is_flag=True, help='reset an existing database')
 @click.option('-a', '--automate', is_flag=True, help='run non-interactively')
+@click.option('-t', '--transcripts', is_flag=True,
+              help='focus only on transcripts on the database level')
 @click.pass_context
-def init(context, setup, reset, automate):
+def init(context, setup, reset, automate, transcripts):
     """Walk user through setting up a new config file."""
     # print a nice welcome message
     click.echo(chanjo.__banner__)
@@ -43,7 +47,9 @@ def init(context, setup, reset, automate):
     context.obj.save(default_flow_style=False)
 
     if setup:
-        chanjo_db = Store(uri=context.obj.user_data['database'])
+        only_tx = transcripts or context.obj.get('transcripts') or False
+        base = TXBASE if only_tx else BASE
+        chanjo_db = Store(uri=context.obj['database'], base=base)
         if reset:
             chanjo_db.tear_down()
         chanjo_db.set_up()

--- a/chanjo/cli/link.py
+++ b/chanjo/cli/link.py
@@ -2,23 +2,43 @@
 import logging
 
 import click
+from sqlalchemy.exc import IntegrityError
 
 from chanjo.load import link as link_mod
+from chanjo import load
 from chanjo.parse import bed
 from chanjo.store import Store
 from chanjo.utils import validate_stdin
+from chanjo.store.models import BASE
+from chanjo.store.txmodels import BASE as TXBASE
 
 logger = logging.getLogger(__name__)
 
 
 @click.command()
+@click.option('-t', '--transcripts', is_flag=True,
+              help='focus only on transcripts on the database level')
 @click.argument('bed_stream', callback=validate_stdin,
                 type=click.File(encoding='utf-8'), default='-', required=False)
 @click.pass_context
-def link(context, bed_stream):
+def link(context, transcripts, bed_stream):
     """Link related genomic elements."""
-    chanjo_db = Store(uri=context.obj['database'])
-    link_elements(chanjo_db, bed_stream)
+    only_tx = transcripts or context.obj.get('transcripts') or False
+    base = TXBASE if only_tx else BASE
+    chanjo_db = Store(uri=context.obj['database'], base=base)
+    try:
+        if only_tx:
+            result = load.link_transcripts(bed_stream)
+            with click.progressbar(result.models, length=result.count,
+                                   label='adding transcripts') as bar:
+                for tx_model in bar:
+                    chanjo_db.session.add(tx_model)
+            chanjo_db.save()
+        else:
+            link_elements(chanjo_db, bed_stream)
+    except IntegrityError:
+        click.echo("elements already linked, use 'chanjo db setup --reset' "
+                   "to re-build")
 
 
 def link_elements(chanjo_db, bed_iterable, batch_size=10000):

--- a/chanjo/cli/load.py
+++ b/chanjo/cli/load.py
@@ -32,14 +32,8 @@ def load(context, sample, group, transcripts, bed_stream):
     try:
         if only_tx:
             source = os.path.abspath(bed_stream.name)
-            kwargs = dict(sample_id=sample, sequence=bed_stream,
-                          group_id=group, source=source)
-            result = load_mod.load_transcripts(**kwargs)
-            with click.progressbar(result.models, length=result.count,
-                                   label='loading transcripts') as bar:
-                for tx_model in bar:
-                    chanjo_db.session.add(tx_model)
-            chanjo_db.save()
+            load_transcripts(chanjo_db, bed_stream, sample=sample, group=group,
+                             source=source)
         else:
             load_sambamba(chanjo_db, bed_stream, sample_id=sample,
                           group_id=group)
@@ -48,6 +42,18 @@ def load(context, sample, group, transcripts, bed_stream):
         logger.debug(error.message)
         chanjo_db.session.rollback()
         context.abort()
+
+
+def load_transcripts(chanjo_db, bed_stream, sample=None, group=None,
+                     source=None):
+    kwargs = dict(sample_id=sample, sequence=bed_stream,
+                  group_id=group, source=source)
+    result = load_mod.load_transcripts(**kwargs)
+    with click.progressbar(result.models, length=result.count,
+                           label='loading transcripts') as bar:
+        for tx_model in bar:
+            chanjo_db.session.add(tx_model)
+    chanjo_db.save()
 
 
 def load_sambamba(chanjo_db, bed_iterable, sample_id=None, group_id=None):

--- a/chanjo/cli/load.py
+++ b/chanjo/cli/load.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
+import os.path
 import logging
 
 import click
 from sqlalchemy.exc import IntegrityError
 
 from chanjo.load.sambamba import rows as sambamba_rows
+from chanjo import load as load_mod
 from chanjo.parse import sambamba
 from chanjo.store import Store
 from chanjo.utils import validate_stdin
+from chanjo.store.models import BASE
+from chanjo.store.txmodels import BASE as TXBASE
 
 logger = logging.getLogger(__name__)
 
@@ -15,16 +19,33 @@ logger = logging.getLogger(__name__)
 @click.command()
 @click.option('-s', '--sample', help='override sample id from file')
 @click.option('-g', '--group', help='id to group related samples')
+@click.option('-t', '--transcripts', is_flag=True,
+              help='focus only on transcripts on the database level')
 @click.argument('bed_stream', callback=validate_stdin,
                 type=click.File(encoding='utf-8'), default='-', required=False)
 @click.pass_context
-def load(context, sample, group, bed_stream):
+def load(context, sample, group, transcripts, bed_stream):
     """Load Sambamba output into the database for a sample."""
-    chanjo_db = Store(uri=context.obj['database'])
+    only_tx = transcripts or context.obj.get('transcripts') or False
+    base = TXBASE if only_tx else BASE
+    chanjo_db = Store(uri=context.obj['database'], base=base)
     try:
-        load_sambamba(chanjo_db, bed_stream, sample_id=sample, group_id=group)
-    except IntegrityError:
+        if only_tx:
+            source = os.path.abspath(bed_stream.name)
+            kwargs = dict(sample_id=sample, sequence=bed_stream,
+                          group_id=group, source=source)
+            result = load_mod.load_transcripts(**kwargs)
+            with click.progressbar(result.models, length=result.count,
+                                   label='loading transcripts') as bar:
+                for tx_model in bar:
+                    chanjo_db.session.add(tx_model)
+            chanjo_db.save()
+        else:
+            load_sambamba(chanjo_db, bed_stream, sample_id=sample,
+                          group_id=group)
+    except IntegrityError as error:
         logger.error('sample already loaded, rolling back')
+        logger.debug(error.message)
         chanjo_db.session.rollback()
         context.abort()
 

--- a/chanjo/load/__init__.py
+++ b/chanjo/load/__init__.py
@@ -1,1 +1,3 @@
 # -*- coding: utf-8 -*-
+from .txlink import process as link_transcripts
+from .txload import process as load_transcripts

--- a/chanjo/load/txlink.py
+++ b/chanjo/load/txlink.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from collections import namedtuple
+
+from chanjo.compat import iteritems
+from chanjo.parse import bed
+from chanjo.store.txmodels import Transcript
+from .utils import groupby_tx
+
+Result = namedtuple('Result', ['models', 'count'])
+
+
+def process(sequence):
+    """Process a sequence of exon lines."""
+    exons = bed.chanjo(sequence)
+    transcripts = groupby_tx(exons)
+    models = (make_model(tx_id, exons) for tx_id, exons in
+              iteritems(transcripts))
+    return Result(models=models, count=len(transcripts))
+
+
+def make_model(transcript_id, exons):
+    """Generate transcript model"""
+    chromosome = exons[0]['chrom']
+    gene_id = exons[0]['elements'][transcript_id]
+    tot_length = sum((exon['chromEnd'] - exon['chromStart']) for exon in exons)
+    tx_model = Transcript(id=transcript_id, chromosome=chromosome,
+                          length=tot_length, gene_id=gene_id)
+    return tx_model

--- a/chanjo/load/txlink.py
+++ b/chanjo/load/txlink.py
@@ -10,7 +10,14 @@ Result = namedtuple('Result', ['models', 'count'])
 
 
 def process(sequence):
-    """Process a sequence of exon lines."""
+    """Process a sequence of exon lines.
+
+    Args:
+        sequence (sequence): list of chanjo bed lines
+
+    Returns:
+        Result: iterators of transcript models, number of transcripts processed
+    """
     exons = bed.chanjo(sequence)
     transcripts = groupby_tx(exons)
     models = (make_model(tx_id, exons) for tx_id, exons in
@@ -19,7 +26,16 @@ def process(sequence):
 
 
 def make_model(transcript_id, exons):
-    """Generate transcript model"""
+    """Generate transcript model from a list of exons.
+
+    Args:
+        transcript_id (str): unique transcript id
+        exons (List[dict]): list of exon dictionaries
+
+    Returns:
+        Transcript: uncommitted transcript model
+    """
+    # assume the same chromosome and gene for all exons
     chromosome = exons[0]['chrom']
     gene_id = exons[0]['elements'][transcript_id]
     tot_length = sum((exon['chromEnd'] - exon['chromStart']) for exon in exons)

--- a/chanjo/load/txload.py
+++ b/chanjo/load/txload.py
@@ -11,7 +11,17 @@ Result = namedtuple('Result', ['models', 'count', 'sample'])
 
 
 def process(sequence, sample_id=None, group_id=None, source=None):
-    """Process a sequence of exon lines."""
+    """Process a sequence of exon lines.
+
+    Args:
+        sequence (sequence): list of chanjo bed lines
+        sample_id (Optional[str]): unique sample id, else auto-guessed
+        grouip_id (Optional[str]): id to group samples
+        source (Optional[str]): path to coverage source (BAM/Sambamba)
+
+    Returns:
+        Result: iterators of `Transcript`, transcripts processed, sample model
+    """
     exons = sambamba.depth_output(sequence)
     transcripts = groupby_tx(exons, sambamba=True)
     raw_stats = ((tx_id, tx_stat(tx_id, exons)) for tx_id, exons in
@@ -26,9 +36,16 @@ def process(sequence, sample_id=None, group_id=None, source=None):
     return Result(models=models, count=len(transcripts), sample=sample_obj)
 
 
-# calculate transcript stats
 def tx_stat(transcript_id, exons):
-    """Generate a transcript stat model."""
+    """Calculate metrics for transcript stats model.
+
+    Args:
+        transcript_id (str): unqiue transcript id
+        exons (List[dict]): list of exon transcripts
+
+    Returns:
+        dict: aggregated stats over all exons
+    """
     sums = {'bases': 0, 'mean_coverage': 0}
 
     # for each of the exons (linked to one transcript)
@@ -52,6 +69,16 @@ def tx_stat(transcript_id, exons):
 
 
 def make_model(sample_obj, transcript_id, fields):
+    """Compose a transcript stat model from fields.
+
+    Args:
+        sample_obj (Sample): Sample database model
+        transcript_id (str): unique transcript id
+        fields (dict): key/values of metrics
+
+    Returns:
+        Transcript: composed transcript model
+    """
     tx_model = TranscriptStat(sample=sample_obj, transcript_id=transcript_id,
                               **fields)
     return tx_model

--- a/chanjo/load/txload.py
+++ b/chanjo/load/txload.py
@@ -77,6 +77,7 @@ def tx_stat(transcript_id, exons, threshold=None):
     fields = {key: (value / sums['bases']) for key, value in iteritems(sums)
               if key != 'bases'}
     fields['incomplete_exons'] = incomplete_exons
+    fields['threshold'] = threshold
     return fields
 
 

--- a/chanjo/load/txload.py
+++ b/chanjo/load/txload.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 from chanjo.compat import iteritems, itervalues
 from chanjo.parse import sambamba
-from chanjo.store.txmodels import TranscriptStat, Sample
+from chanjo.store.txmodels import TranscriptStat, Sample, Exon
 from .utils import groupby_tx
 
 Result = namedtuple('Result', ['models', 'count', 'sample'])
@@ -69,10 +69,9 @@ def tx_stat(transcript_id, exons, threshold=None):
                 sums[sums_key] += (completeness * exon_length)
 
                 if threshold == comp_key and completeness < 100:
-                    exon_id = "{}:{}-{}".format(exon['chrom'],
-                                                exon['chromStart'],
-                                                exon['chromEnd'])
-                    incomplete_exons.append(exon_id)
+                    exon_obj = Exon(exon['chrom'], exon['chromStart'],
+                                    exon['chromEnd'], completeness)
+                    incomplete_exons.append(exon_obj)
 
     fields = {key: (value / sums['bases']) for key, value in iteritems(sums)
               if key != 'bases'}

--- a/chanjo/load/utils.py
+++ b/chanjo/load/utils.py
@@ -28,3 +28,19 @@ def get_or_build_exon(session, exon_filters):
         # no existing exon object, create a new one
         exon_obj = Exon(**exon_filters)
     return exon_obj
+
+
+def groupby_tx(exons, sambamba=False):
+    """Group (unordered) exons per transcript."""
+    transcripts = {}
+    for exon in exons:
+        if sambamba:
+            exon['elements'] = dict(zip(exon['extraFields'][-2].split(','),
+                                        exon['extraFields'][-1].split(',')))
+        else:
+            exon['elements'] = dict(exon['elements'])
+        for transcript_id in exon['elements']:
+            if transcript_id not in transcripts:
+                transcripts[transcript_id] = []
+            transcripts[transcript_id].append(exon)
+    return transcripts

--- a/chanjo/store/core.py
+++ b/chanjo/store/core.py
@@ -39,9 +39,11 @@ class Store(object):
     Args:
         uri (Optional[str]): path/URI to the database to connect to
         debug (Optional[bool]): whether to output logging information
+        base (Optional[sqlalchemy.ext.declarative.api.Base]): schema definition
 
     Attributes:
         uri (str): path/URI to the database to connect to
+        base (sqlalchemy.ext.declarative.api.Base): shcema definition
         engine (class): SQLAlchemy engine, defines what database to use
         session (class): SQLAlchemy ORM session, manages persistance
         query (method): SQLAlchemy ORM query builder method

--- a/chanjo/store/models.py
+++ b/chanjo/store/models.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 
 from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer, String,
-                        Table, UniqueConstraint)
+                        UniqueConstraint)
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -16,11 +16,16 @@ BASE = declarative_base()
 # | Provides the many-to-many relationships between:
 # | - Exon<->Transcript
 # +--------------------------------------------------------------------+
-Exon_Transcript = Table(
-    'exon__transcript',
-    BASE.metadata,
-    Column('exon_id', Integer, ForeignKey('exon.id')),
-    Column('transcript_id', Integer, ForeignKey('transcript.id')))
+class ExonTranscriptLink(BASE):
+
+    """Link between exon and transcript."""
+
+    __tablename__ = 'exon__transcript'
+    __table_args__ = (UniqueConstraint('exon_id', 'transcript_id',
+                                       name='_exon_transcript_uc'),)
+
+    exon_id = Column(Integer, ForeignKey('exon.id'))
+    transcript_id = Column(Integer, ForeignKey('transcript.id'))
 
 
 # +--------------------------------------------------------------------+
@@ -93,7 +98,7 @@ class Exon(BASE):
     start = Column(Integer, nullable=False)
     end = Column(Integer, nullable=False)
 
-    transcripts = relationship(Transcript, secondary=Exon_Transcript,
+    transcripts = relationship(Transcript, secondary=ExonTranscriptLink,
                                backref=backref('exons', order_by=start))
 
     def __len__(self):

--- a/chanjo/store/models.py
+++ b/chanjo/store/models.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 
 from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer, String,
-                        UniqueConstraint)
+                        UniqueConstraint, Table)
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -16,16 +16,11 @@ BASE = declarative_base()
 # | Provides the many-to-many relationships between:
 # | - Exon<->Transcript
 # +--------------------------------------------------------------------+
-class ExonTranscriptLink(BASE):
-
-    """Link between exon and transcript."""
-
-    __tablename__ = 'exon__transcript'
-    __table_args__ = (UniqueConstraint('exon_id', 'transcript_id',
-                                       name='_exon_transcript_uc'),)
-
-    exon_id = Column(Integer, ForeignKey('exon.id'))
-    transcript_id = Column(Integer, ForeignKey('transcript.id'))
+Exon_Transcript = Table(
+    'exon__transcript',
+    BASE.metadata,
+    Column('exon_id', Integer, ForeignKey('exon.id')),
+    Column('transcript_id', Integer, ForeignKey('transcript.id')))
 
 
 # +--------------------------------------------------------------------+
@@ -98,7 +93,7 @@ class Exon(BASE):
     start = Column(Integer, nullable=False)
     end = Column(Integer, nullable=False)
 
-    transcripts = relationship(Transcript, secondary=ExonTranscriptLink,
+    transcripts = relationship(Transcript, secondary=Exon_Transcript,
                                backref=backref('exons', order_by=start))
 
     def __len__(self):

--- a/chanjo/store/txmodels.py
+++ b/chanjo/store/txmodels.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+from sqlalchemy import Column, types, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship, backref
+from sqlalchemy.ext.declarative import declarative_base
+
+# base for declaring a mapping
+BASE = declarative_base()
+
+
+# +--------------------------------------------------------------------+
+# | Transcript ORM
+# +--------------------------------------------------------------------+
+class Transcript(BASE):
+
+    """Set of non-overlapping exons.
+
+    A :class:`Transcript` can *only* be related to a single gene.
+
+    Args:
+        transcript_id (str): unique block id (e.g. CCDS transcript id)
+        gene_id (str): related gene
+    """
+
+    __tablename__ = 'transcript'
+
+    id = Column(types.String(32), primary_key=True)
+    gene_id = Column(types.String(32), index=True, nullable=False)
+    chromosome = Column(types.String(10))
+    length = Column(types.Integer)
+
+
+# +--------------------------------------------------------------------+
+# | Sample ORM classes
+# +--------------------------------------------------------------------+
+class Sample(BASE):
+
+    """Metadata for a single (unique) sample.
+
+    :class:`Sample` helps out in consolidating important information in
+    one place.
+
+    .. versionadded:: 0.4.0
+
+    Args:
+        sample_id (str): unique sample id
+        group_id (str): unique group id
+        cutoff (int): cutoff used for completeness
+        extension (bool): number of bases added to each interval
+        coverage_source (str): path to the BAM file used
+    """
+
+    __tablename__ = 'sample'
+
+    id = Column(types.String(32), primary_key=True)
+    group_id = Column(types.String(32), index=True)
+    source = Column(types.String(128))
+    created_at = Column(types.DateTime, default=datetime.now)
+
+
+# +--------------------------------------------------------------------+
+# | Transcript Stat ORM
+# +--------------------------------------------------------------------+
+class TranscriptStat(BASE):
+
+    """Statistics on transcript level, related to sample and transcript.
+
+    Args:
+        metric (str): identifier for the metric
+        value (float): value for the metric
+        sample (Sample): parent record Sample
+        exon (Exon): parent record Exon
+        sample_id (int): parent record Sample id
+        exon_id (int): parent record Exon id
+    """
+
+    __tablename__ = 'transcript_stat'
+    __table_args__ = (UniqueConstraint('sample_id', 'transcript_id',
+                                       name='_sample_transcript_uc'),)
+
+    id = Column(types.Integer, primary_key=True)
+    sample_id = Column(types.String(32), ForeignKey('sample.id'),
+                       nullable=False)
+    sample = relationship(Sample, backref=backref('stats'))
+    transcript_id = Column(types.String(32), ForeignKey('transcript.id'),
+                           nullable=False)
+    transcript = relationship(Transcript, backref=backref('stats'))
+    mean_coverage = Column(types.Float, nullable=False)
+    completeness_10 = Column(types.Float)
+    completeness_15 = Column(types.Float)
+    completeness_20 = Column(types.Float)
+    completeness_50 = Column(types.Float)
+    completeness_100 = Column(types.Float)

--- a/chanjo/store/txmodels.py
+++ b/chanjo/store/txmodels.py
@@ -55,7 +55,7 @@ class Sample(BASE):
 
     id = Column(types.String(32), primary_key=True)
     group_id = Column(types.String(32), index=True)
-    source = Column(types.String(128))
+    source = Column(types.String(256))
     created_at = Column(types.DateTime, default=datetime.now)
 
 

--- a/chanjo/store/txmodels.py
+++ b/chanjo/store/txmodels.py
@@ -9,9 +9,6 @@ from sqlalchemy.ext.declarative import declarative_base
 BASE = declarative_base()
 
 
-# +--------------------------------------------------------------------+
-# | Transcript ORM
-# +--------------------------------------------------------------------+
 class Transcript(BASE):
 
     """Set of non-overlapping exons.
@@ -19,8 +16,10 @@ class Transcript(BASE):
     A :class:`Transcript` can *only* be related to a single gene.
 
     Args:
-        transcript_id (str): unique block id (e.g. CCDS transcript id)
+        id (str): unique transcript id (e.g. CCDS)
         gene_id (str): related gene
+        chromosome (str): related contig id
+        lenght (int): number of exon bases in transcript
     """
 
     __tablename__ = 'transcript'
@@ -31,24 +30,15 @@ class Transcript(BASE):
     length = Column(types.Integer)
 
 
-# +--------------------------------------------------------------------+
-# | Sample ORM classes
-# +--------------------------------------------------------------------+
 class Sample(BASE):
 
-    """Metadata for a single (unique) sample.
-
-    :class:`Sample` helps out in consolidating important information in
-    one place.
-
-    .. versionadded:: 0.4.0
+    """Metadata for a single sample.
 
     Args:
-        sample_id (str): unique sample id
+        id (str): unique sample id
         group_id (str): unique group id
-        cutoff (int): cutoff used for completeness
-        extension (bool): number of bases added to each interval
-        coverage_source (str): path to the BAM file used
+        source (str): path to coverage source Sambamba output/BAM file
+        created_at (DateTime): date of addition to database
     """
 
     __tablename__ = 'sample'
@@ -59,20 +49,17 @@ class Sample(BASE):
     created_at = Column(types.DateTime, default=datetime.now)
 
 
-# +--------------------------------------------------------------------+
-# | Transcript Stat ORM
-# +--------------------------------------------------------------------+
 class TranscriptStat(BASE):
 
     """Statistics on transcript level, related to sample and transcript.
 
     Args:
-        metric (str): identifier for the metric
-        value (float): value for the metric
-        sample (Sample): parent record Sample
-        exon (Exon): parent record Exon
-        sample_id (int): parent record Sample id
-        exon_id (int): parent record Exon id
+        sample_id (str): link to sample record
+        sample (Sample): parent Sample record
+        transcript_id (str): link to transcript record
+        transcript (Transcript): parent transcript record
+        mean_coverage (Float): mean coverage across all exons
+        completeness_XX (Float): percentage of exon bases coverage at XX
     """
 
     __tablename__ = 'transcript_stat'

--- a/chanjo/store/txmodels.py
+++ b/chanjo/store/txmodels.py
@@ -60,6 +60,7 @@ class TranscriptStat(BASE):
         transcript (Transcript): parent transcript record
         mean_coverage (Float): mean coverage across all exons
         completeness_XX (Float): percentage of exon bases coverage at XX
+        _incomplete_exons (str): comma separated list of exon ids
     """
 
     __tablename__ = 'transcript_stat'
@@ -79,3 +80,13 @@ class TranscriptStat(BASE):
     completeness_20 = Column(types.Float)
     completeness_50 = Column(types.Float)
     completeness_100 = Column(types.Float)
+    _incomplete_exons = Column(types.Text)
+
+    @property
+    def incomplete_exons(self):
+        """Return a list of exons ids."""
+        return self._incomplete_exons.split(',') if self._incomplete_exons else []
+
+    @incomplete_exons.setter
+    def incomplete_exons(self, value):
+        self._incomplete_exons = ','.join(value)

--- a/chanjo/store/txmodels.py
+++ b/chanjo/store/txmodels.py
@@ -80,6 +80,8 @@ class TranscriptStat(BASE):
     completeness_20 = Column(types.Float)
     completeness_50 = Column(types.Float)
     completeness_100 = Column(types.Float)
+
+    threshold = Column(types.Integer)
     _incomplete_exons = Column(types.Text)
 
     @property


### PR DESCRIPTION
oki, this is my suggestion to solve the space/RAM issue

We store transcripts instead of exons and read in the aggregated metrics from the same input file. You can add a key "transcripts" to the config or use the "--transcript" flag to tell chanjo to use the alternative schema.

The default is still to use the old schema so nothing changes if you use that

Testing and documentation to come