### PR TITLE
Alchy

### DIFF
--- a/chanjo/cli/load.py
+++ b/chanjo/cli/load.py
@@ -51,6 +51,7 @@ def load_transcripts(chanjo_db, bed_stream, sample=None, group=None,
     kwargs = dict(sample_id=sample, sequence=bed_stream,
                   group_id=group, source=source, threshold=threshold)
     result = load_mod.load_transcripts(**kwargs)
+    chanjo_db.session.add(result.sample)
     with click.progressbar(result.models, length=result.count,
                            label='loading transcripts') as bar:
         for tx_model in bar:

--- a/chanjo/load/sambamba.py
+++ b/chanjo/load/sambamba.py
@@ -72,9 +72,9 @@ def statistics(data, sample_obj, exon_obj=None, exon_id=None):
         List[ExonStatistic]: stats models linked to exon and sample
     """
     if exon_obj:
-        relationships = dict(sample=sample_obj, exon=exon_obj)
+        relationships = dict(sample_id=sample_obj.id, exon_id=exon_obj.id)
     else:
-        relationships = dict(sample=sample_obj, exon_id=exon_id)
+        relationships = dict(sample_id=sample_obj.id, exon_id=exon_id)
     stats = [ExonStatistic(metric='mean_coverage', value=data['meanCoverage'],
                            **relationships)]
     for threshold, value in iteritems(data['thresholds']):

--- a/chanjo/load/sambamba.py
+++ b/chanjo/load/sambamba.py
@@ -32,7 +32,7 @@ def rows(session, row_data, sample_id=None, group_id=None):
 
     exons = {exon.exon_id: exon.id for exon in session.query(Exon)}
     sample_obj = Sample(sample_id=sample_id, group_id=group_id)
-    nested_stats = (row(session, data, sample_obj, exons) for data in all_data)
+    nested_stats = [row(session, data, sample_obj, exons) for data in all_data]
     # flatten 2D nested list
     return (stat for stats in nested_stats for stat in stats)
 

--- a/chanjo/load/txload.py
+++ b/chanjo/load/txload.py
@@ -91,6 +91,6 @@ def make_model(sample_obj, transcript_id, fields):
     Returns:
         Transcript: composed transcript model
     """
-    tx_model = TranscriptStat(sample=sample_obj, transcript_id=transcript_id,
-                              **fields)
+    tx_model = TranscriptStat(sample_id=sample_obj.id,
+                              transcript_id=transcript_id, **fields)
     return tx_model

--- a/chanjo/store/api.py
+++ b/chanjo/store/api.py
@@ -4,7 +4,6 @@ import itertools
 import logging
 
 from sqlalchemy.sql import func
-from sqlalchemy.orm import scoped_session, sessionmaker
 
 from chanjo.compat import itervalues
 from chanjo.utils import list_get
@@ -23,31 +22,6 @@ class ChanjoAPI(Store, ChanjoConverterMixin):
     Attributes:
         weighten_average (BinaryExpression): weighter mean for metrics
     """
-
-    def init_app(self, app, key_base='CHANJO_'):
-        """Configure API (Flask style) after lazy initialization.
-
-        Args:
-            app (Flask): Flask app instance
-            key_base (str): namespace to look for under ``app.config``
-
-        Returns:
-            ChanjoAPI: ``self``
-        """
-        @app.teardown_appcontext
-        def shutdown_session(response_or_exc):
-            app.logger.debug("tear down session")
-            self.session.remove()
-            return response_or_exc
-
-        @app.before_request
-        def setup_session():
-            app.logger.debug("set up new session")
-            self.session = scoped_session(sessionmaker(bind=self.engine))
-
-        uri = app.config["{}URI".format(key_base)]
-        self.connect(db_uri=uri)
-        return self
 
     @property
     def weighted_average(self):

--- a/chanjo/store/core.py
+++ b/chanjo/store/core.py
@@ -82,7 +82,7 @@ class Store(Manager):
         super(Store, self).__init__(config=config, Model=self.Model)
 
         # shortcut to query method
-        self.query = self.session.query_property()
+        self.query = self.session.query
         return self
 
     @property

--- a/chanjo/store/core.py
+++ b/chanjo/store/core.py
@@ -8,12 +8,10 @@ import logging
 import os
 
 from alchy import Manager
-from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.sql.expression import ClauseElement
 
-from .models import (Model, Gene, Transcript, Exon, Sample)
+from .models import (BASE, Gene, Transcript, Exon, Sample)
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +49,8 @@ class Store(Manager):
         classes (dict): bound ORM classes
     """
 
-    def __init__(self, uri=None, debug=False, Model=Model):
-        self.Model = Model
+    def __init__(self, uri=None, debug=False, base=BASE):
+        self.Model = base
         self.uri = uri
         if uri:
             self.connect(uri, debug=debug)

--- a/chanjo/store/core.py
+++ b/chanjo/store/core.py
@@ -7,17 +7,18 @@ from __future__ import division
 import logging
 import os
 
+from alchy import Manager
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.sql.expression import ClauseElement
 
-from .models import (BASE, Gene, Transcript, Exon, Sample)
+from .models import (Model, Gene, Transcript, Exon, Sample)
 
 logger = logging.getLogger(__name__)
 
 
-class Store(object):
+class Store(Manager):
 
     """SQLAlchemy-based database object.
 
@@ -50,10 +51,9 @@ class Store(object):
         classes (dict): bound ORM classes
     """
 
-    def __init__(self, uri=None, debug=False, base=BASE):
-        super(Store, self).__init__()
+    def __init__(self, uri=None, debug=False, Model=Model):
+        self.Model = Model
         self.uri = uri
-        self.base = base
         if uri:
             self.connect(uri, debug=debug)
 
@@ -70,22 +70,21 @@ class Store(object):
             db_uri (str): path/URI to the database to connect to
             debug (Optional[bool]): whether to output logging information
         """
-        kwargs = {'echo': debug, 'convert_unicode': True}
-        # connect to the SQL database
+        config = {'SQLALCHEMY_ECHO': debug}
         if 'mysql' in db_uri:
-            kwargs['pool_recycle'] = 3600
+            config['SQLALCHEMY_POOL_RECYCLE'] = 3600
         elif '://' not in db_uri:
             # expect only a path to a sqlite database
             db_path = os.path.abspath(os.path.expanduser(db_uri))
             db_uri = "sqlite:///{}".format(db_path)
 
-        self.engine = create_engine(db_uri, **kwargs)
-        # make sure the same engine is propagated to the BASE classes
-        self.base.metadata.bind = self.engine
-        # start a session
-        self.session = scoped_session(sessionmaker(bind=self.engine))
+        config['SQLALCHEMY_DATABASE_URI'] = db_uri
+
+        # connect to the SQL database
+        super(Store, self).__init__(config=config, Model=self.Model)
+
         # shortcut to query method
-        self.query = self.session.query
+        self.query = self.session.query_property()
         return self
 
     @property
@@ -106,8 +105,8 @@ class Store(object):
             Store: self
         """
         # create the tables
-        self.base.metadata.create_all(self.engine)
-        tables = self.base.metadata.tables.keys()
+        self.create_all()
+        tables = self.Model.metadata.tables.keys()
         logger.info("created tables: %s", ', '.join(tables))
         return self
 
@@ -118,7 +117,7 @@ class Store(object):
             Store: self
         """
         # drop/delete the tables
-        self.base.metadata.drop_all(self.engine)
+        self.drop_all()
         return self
 
     def get_or_create(self, model, **kwargs):

--- a/chanjo/store/models.py
+++ b/chanjo/store/models.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 
+from alchy import ModelBase, make_declarative_base
 from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer, String,
                         UniqueConstraint, Table)
 from sqlalchemy.orm import relationship, backref
-from sqlalchemy.ext.declarative import declarative_base
 
 # base for declaring a mapping
-BASE = declarative_base()
+Model = make_declarative_base(Base=ModelBase)
 
 
 # +--------------------------------------------------------------------+
@@ -18,7 +18,7 @@ BASE = declarative_base()
 # +--------------------------------------------------------------------+
 Exon_Transcript = Table(
     'exon__transcript',
-    BASE.metadata,
+    Model.metadata,
     Column('exon_id', Integer, ForeignKey('exon.id')),
     Column('transcript_id', Integer, ForeignKey('transcript.id')))
 
@@ -26,7 +26,7 @@ Exon_Transcript = Table(
 # +--------------------------------------------------------------------+
 # | Gene ORM
 # +--------------------------------------------------------------------+
-class Gene(BASE):
+class Gene(Model):
 
     """Collection of transcripts and potentially overlapping exons.
 
@@ -46,7 +46,7 @@ class Gene(BASE):
 # +--------------------------------------------------------------------+
 # | Transcript ORM
 # +--------------------------------------------------------------------+
-class Transcript(BASE):
+class Transcript(Model):
 
     """Set of non-overlapping exons.
 
@@ -69,7 +69,7 @@ class Transcript(BASE):
 # +--------------------------------------------------------------------+
 # | Exon ORM
 # +--------------------------------------------------------------------+
-class Exon(BASE):
+class Exon(Model):
 
     """A continous genetic interval on a given contig.
 
@@ -109,7 +109,7 @@ class Exon(BASE):
 # +--------------------------------------------------------------------+
 # | Sample ORM classes
 # +--------------------------------------------------------------------+
-class Sample(BASE):
+class Sample(Model):
 
     """Metadata for a single (unique) sample.
 
@@ -138,7 +138,7 @@ class Sample(BASE):
 # +--------------------------------------------------------------------+
 # | Exon Data ORM
 # +--------------------------------------------------------------------+
-class ExonStatistic(BASE):
+class ExonStatistic(Model):
 
     """Statistics on the exon level, related to sample and exon.
 

--- a/chanjo/store/models.py
+++ b/chanjo/store/models.py
@@ -7,7 +7,7 @@ from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer, String,
 from sqlalchemy.orm import relationship, backref
 
 # base for declaring a mapping
-Model = make_declarative_base(Base=ModelBase)
+BASE = make_declarative_base(Base=ModelBase)
 
 
 # +--------------------------------------------------------------------+
@@ -18,7 +18,7 @@ Model = make_declarative_base(Base=ModelBase)
 # +--------------------------------------------------------------------+
 Exon_Transcript = Table(
     'exon__transcript',
-    Model.metadata,
+    BASE.metadata,
     Column('exon_id', Integer, ForeignKey('exon.id')),
     Column('transcript_id', Integer, ForeignKey('transcript.id')))
 
@@ -26,7 +26,7 @@ Exon_Transcript = Table(
 # +--------------------------------------------------------------------+
 # | Gene ORM
 # +--------------------------------------------------------------------+
-class Gene(Model):
+class Gene(BASE):
 
     """Collection of transcripts and potentially overlapping exons.
 
@@ -46,7 +46,7 @@ class Gene(Model):
 # +--------------------------------------------------------------------+
 # | Transcript ORM
 # +--------------------------------------------------------------------+
-class Transcript(Model):
+class Transcript(BASE):
 
     """Set of non-overlapping exons.
 
@@ -69,7 +69,7 @@ class Transcript(Model):
 # +--------------------------------------------------------------------+
 # | Exon ORM
 # +--------------------------------------------------------------------+
-class Exon(Model):
+class Exon(BASE):
 
     """A continous genetic interval on a given contig.
 
@@ -109,7 +109,7 @@ class Exon(Model):
 # +--------------------------------------------------------------------+
 # | Sample ORM classes
 # +--------------------------------------------------------------------+
-class Sample(Model):
+class Sample(BASE):
 
     """Metadata for a single (unique) sample.
 
@@ -138,7 +138,7 @@ class Sample(Model):
 # +--------------------------------------------------------------------+
 # | Exon Data ORM
 # +--------------------------------------------------------------------+
-class ExonStatistic(Model):
+class ExonStatistic(BASE):
 
     """Statistics on the exon level, related to sample and exon.
 

--- a/chanjo/store/txmodels.py
+++ b/chanjo/store/txmodels.py
@@ -9,10 +9,10 @@ from sqlalchemy.orm import relationship, backref
 Exon = namedtuple('Exon', ['chrom', 'start', 'end', 'completeness'])
 
 # base for declaring a mapping
-Model = make_declarative_base(Base=ModelBase)
+BASE = make_declarative_base(Base=ModelBase)
 
 
-class Transcript(Model):
+class Transcript(BASE):
 
     """Set of non-overlapping exons.
 
@@ -33,7 +33,7 @@ class Transcript(Model):
     length = Column(types.Integer)
 
 
-class Sample(Model):
+class Sample(BASE):
 
     """Metadata for a single sample.
 
@@ -52,7 +52,7 @@ class Sample(Model):
     created_at = Column(types.DateTime, default=datetime.now)
 
 
-class TranscriptStat(Model):
+class TranscriptStat(BASE):
 
     """Statistics on transcript level, related to sample and transcript.
 

--- a/chanjo/store/txmodels.py
+++ b/chanjo/store/txmodels.py
@@ -2,17 +2,17 @@
 from collections import namedtuple
 from datetime import datetime
 
+from alchy import ModelBase, make_declarative_base
 from sqlalchemy import Column, types, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import relationship, backref
-from sqlalchemy.ext.declarative import declarative_base
 
 Exon = namedtuple('Exon', ['chrom', 'start', 'end', 'completeness'])
 
 # base for declaring a mapping
-BASE = declarative_base()
+Model = make_declarative_base(Base=ModelBase)
 
 
-class Transcript(BASE):
+class Transcript(Model):
 
     """Set of non-overlapping exons.
 
@@ -33,7 +33,7 @@ class Transcript(BASE):
     length = Column(types.Integer)
 
 
-class Sample(BASE):
+class Sample(Model):
 
     """Metadata for a single sample.
 
@@ -52,7 +52,7 @@ class Sample(BASE):
     created_at = Column(types.DateTime, default=datetime.now)
 
 
-class TranscriptStat(BASE):
+class TranscriptStat(Model):
 
     """Statistics on transcript level, related to sample and transcript.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 SQLAlchemy>=0.8.2
+alchy
 PyYAML
 click
 path.py

--- a/tests/store/test_store_core.py
+++ b/tests/store/test_store_core.py
@@ -15,9 +15,6 @@ def test_lazy_load():
     """Test connection after post-init."""
     store = Store()
 
-    # now we shouldn't have access to aliases
-    assert hasattr(store, 'query') is False
-
     store.connect('sqlite://')
 
     # ... but now we do!

--- a/tests/store/test_store_core.py
+++ b/tests/store/test_store_core.py
@@ -16,7 +16,7 @@ def test_lazy_load():
     store = Store()
 
     # now we shouldn't have access to aliases
-    assert hasattr(store, 'query') == False
+    assert hasattr(store, 'query') is False
 
     store.connect('sqlite://')
 


### PR DESCRIPTION
Okey!

This is is. I've switched to Alchy which is a wrapper around SQLAlchemy and makes defining models more flexible.

The reason behind this update is to be able to use the same models when using the API in a server setting with a long running process as well as in the CLI. Then you want to leverage something like Flask-SQLAlchemy and this was not possible until now

I've intentionally kept the API the same as before so this should only be a .X update :)