### PR TITLE
Changes for Clinical-Genomics fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install chanjo
 git clone https://github.com/robinandeer/chanjo.git
 cd chanjo
 conda install --channel bioconda sambamba
-pip install --requirements requirements-dev.txt --editable .
+pip install -r requirements-dev.txt --editable .
 ```
 
 ## Usage
@@ -59,7 +59,7 @@ the entire genome. Detailed histograms is something [BEDTools][bedtools]
 already handles with confidence.
 
 ## Contributors
--   Robin Andeer
+-   Robin Andeer ([robinandeer](https://github.com/robinandeer))
 -   Luca Beltrame ([lbeltrame](https://github.com/lbeltrame))
 -   John Kern ([kern3020](https://github.com/kern3020))
 -   Måns Magnusson ([moonso](https://github.com/moonso))

--- a/docs/topics/installation.md
+++ b/docs/topics/installation.md
@@ -25,7 +25,7 @@ $ pip install pymysql
 Would you like to take part in the development or tweak the code for any other reason? In that case, you should follow these simple steps and download the code from the [GitHub repo][repo].
 
 ```bash
-$ git clone https://github.com/robinandeer/chanjo.git
+$ git clone https://github.com/Clinical-Genomics/chanjo.git
 $ cd chanjo
 $ pip install --editable .
 ```


### PR DESCRIPTION
Changed clone path to Clinical-Genomics to reflect this fork.
Changed pip install flag to -r since the --requirements flag gave an error