### PR TITLE
Fix #278 - add a build option to chanjo sex check for 38 coords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add a `--build` option to the sex command, to use different regions on X and Y for genome build 38
 ### Changed
-- Narrow sex chromosome regions that give an `unknown` call
+- Narrow sex chromosome ratios that give an `unknown` sex call
 
 ## [4.8] - 2025-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+### Added
+- Add a `--build` option to the sex command, to use different regions on X and Y for genome build 38
+
 ## [4.8] - 2025-12-03
 ### Added
 - A `--build` option to the init command, to be able to automatically bootstrap a database in genome build 38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Added
 - Add a `--build` option to the sex command, to use different regions on X and Y for genome build 38
+### Changed
+- Narrow sex chromosome regions that give an `unknown` call
 
 ## [4.8] - 2025-12-03
 ### Added

--- a/chanjo/__init__.py
+++ b/chanjo/__init__.py
@@ -7,6 +7,7 @@ Coverage analysis for clinical sequencing.
 :copyright: (c) 2014 by Robin Andeer
 :licence: MIT, see LICENCE for more details
 """
+
 import logging
 
 try:

--- a/chanjo/cli/base.py
+++ b/chanjo/cli/base.py
@@ -4,6 +4,7 @@ Command line interface (console entry points). Based on Click_.
 
 .. _Click: http://click.pocoo.org/
 """
+
 import logging
 import os
 

--- a/chanjo/cli/sex.py
+++ b/chanjo/cli/sex.py
@@ -10,12 +10,20 @@ LOG = logging.getLogger(__name__)
 
 @click.command()
 @click.option("-p", "--prefix", default="", help="chromosome prefix")
+@click.option(
+    "-b",
+    "--build",
+    type=click.Choice(["37", "38"]),
+    default="37",
+    show_default=True,
+    help="Genome version to use.",
+)
 @click.argument("bam_path", type=click.Path(exists=True))
 @click.pass_context
-def sex(context, prefix, bam_path):
+def sex(context, prefix, bam_path, build):
     """Guess the sex of a BAM alignment."""
     try:
-        result = sex_from_bam(bam_path, prefix=prefix)
+        result = sex_from_bam(bam_path, prefix=prefix, build=build)
     except Exception:
         LOG.exception("Something went really wrong :(")
         context.abort()

--- a/chanjo/load/parse/bed.py
+++ b/chanjo/load/parse/bed.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Parse BED files including Sambamba output files."""
+
 from chanjo.exc import BedFormattingError
 
 

--- a/chanjo/load/parse/sambamba.py
+++ b/chanjo/load/parse/sambamba.py
@@ -2,6 +2,7 @@
 """
 Parse the sambamba "depth region" output.
 """
+
 from chanjo.exc import BedFormattingError
 
 

--- a/chanjo/sex.py
+++ b/chanjo/sex.py
@@ -44,7 +44,7 @@ def predict_sex(x_coverage, y_coverage):
             return "female"
 
 
-def sex_from_bam(bam_path, prefix=""):
+def sex_from_bam(bam_path, prefix="", build="37"):
     """Predict the sex from a BAM alignment file.
 
     Args:
@@ -59,7 +59,12 @@ def sex_from_bam(bam_path, prefix=""):
         SexGuess(x_coverage=123.31, y_coverage=0.13, sex='female')
     """
     # make up some sex chromosome regions
-    regions = ["{}X:1-59373566".format(prefix), "{}Y:69362-11375310".format(prefix)]
+    if build == "37":
+        regions = ["{}X:1-59373566".format(prefix), "{}Y:69362-11375310".format(prefix)]
+    else:
+        # build 38
+        regions = ["{}X:2781481-155701382".format(prefix), "{}Y:2791481-56887903".format(prefix)]
+
     averages = []
     for region in regions:
         command = ["sambamba depth region -L {} {}".format(region, bam_path)]

--- a/chanjo/sex.py
+++ b/chanjo/sex.py
@@ -5,6 +5,7 @@ The component reads coverage for subsections of each sex chromosome.
 Based on the ratio between the average coverage across chromosomes it
 makes a simple sex prediction.
 """
+
 from __future__ import division
 
 import logging

--- a/chanjo/sex.py
+++ b/chanjo/sex.py
@@ -35,7 +35,7 @@ def predict_sex(x_coverage, y_coverage):
         return "female"
     else:
         ratio = x_coverage / y_coverage
-        if x_coverage == 0 or (ratio > 12 and ratio < 100):
+        if x_coverage == 0 or (ratio > 12 and ratio < 24):
             return "unknown"
         elif ratio <= 12:
             # this is the entire prediction, it's usually very obvious
@@ -63,7 +63,7 @@ def sex_from_bam(bam_path, prefix="", build="37"):
     if build == "37":
         regions = ["{}X:1-59373566".format(prefix), "{}Y:69362-11375310".format(prefix)]
     else:
-        # build 38
+        # build 38 - use non-PAR regions
         regions = ["{}X:2781481-155701382".format(prefix), "{}Y:2791481-56887903".format(prefix)]
 
     averages = []

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Based on https://github.com/pypa/sampleproject/blob/master/setup.py."""
+
 # To use a consistent encoding
 import codecs
 import os

--- a/tests/test_sex.py
+++ b/tests/test_sex.py
@@ -13,7 +13,9 @@ def test_SexGuess():
 
 def test_predict_sex():
     assert predict_sex(x_coverage=10.2, y_coverage=8.1) == "male"
+    assert predict_sex(x_coverage=26.2, y_coverage=16.9) == "male"
     assert predict_sex(x_coverage=20.9, y_coverage=0.01) == "female"
+    assert predict_sex(x_coverage=37.95, y_coverage=1.09) == "female"
     # shouldn't raise ``ZeroDivisionError``
     assert predict_sex(x_coverage=5.12, y_coverage=0) == "female"
     # what does this even mean?
@@ -23,5 +25,11 @@ def test_predict_sex():
 def test_sex_from_bam(bam_path):
     # use fixtures bam - doesn't have coverage on Y chromosome
     result = sex_from_bam(bam_path)
+    assert result.x_coverage > result.y_coverage
+    assert result.sex == "female"
+
+def test_sex_from_bam_38(bam_path):
+    # use fixtures bam - doesn't have coverage on Y chromosome
+    result = sex_from_bam(bam_path, build="38")
     assert result.x_coverage > result.y_coverage
     assert result.sex == "female"

--- a/tests/test_sex.py
+++ b/tests/test_sex.py
@@ -28,6 +28,7 @@ def test_sex_from_bam(bam_path):
     assert result.x_coverage > result.y_coverage
     assert result.sex == "female"
 
+
 def test_sex_from_bam_38(bam_path):
     # use fixtures bam - doesn't have coverage on Y chromosome
     result = sex_from_bam(bam_path, build="38")


### PR DESCRIPTION
## Description

### Added

- Fix #278 - build option to chanjo bam sex check 

The real issue was not the interval used in the `bam_check`. 
It was strange already for 37. But, let's add a genome option anyway - it doesn't make sense to do the same coordinates for different builds, regardless.
The real issue, again, was with the use of `predict_sex` from `chanjo_report`. Here, we give the recorded coverage over X and Y from the chanjo db. No funky intervals, but apparently different ratios with 38. And absolutely vs the interval. 😆 

These checks are actually fine:
<img width="170" height="81" alt="Screenshot 2026-05-07 at 16 31 34" src="https://github.com/user-attachments/assets/61b36a58-5592-43e1-8da2-47edd2409b6e" />
<img width="552" height="109" alt="Screenshot 2026-05-07 at 16 25 20" src="https://github.com/user-attachments/assets/decb2706-6b71-4fa8-a964-d8466898dd75" />
and 
<img width="658" height="143" alt="Screenshot 2026-05-07 at 16 26 08" src="https://github.com/user-attachments/assets/be861094-641a-4c02-b822-7d3db7e221f3" />
<img width="134" height="80" alt="Screenshot 2026-05-07 at 16 25 56" src="https://github.com/user-attachments/assets/50cfb938-a88d-42fd-afbc-12d671dd096e" />

To fix it, we narrow the interval that gives "unknown" sex. The ratios are already very high, and it is likely this will work just fine.

So far, all female ratios appear to be in the 25-35 range: no need to cap it, all the older much higher ratios are still fine.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
